### PR TITLE
feat: 都道府県抽出APIフロントエンド画面を実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 Homestead.json
 Homestead.yaml
 Thumbs.db
+
+docs/SearchPrefectureApi.php
+docs/PrefectureResolver.php

--- a/public/css/prefecture.css
+++ b/public/css/prefecture.css
@@ -135,13 +135,29 @@ button:disabled {
 
 .examples li {
     margin-bottom: 8px;
+}
+
+.example-btn {
+    display: block;
+    width: 100%;
+    background: none;
+    border: none;
     color: #666;
     cursor: pointer;
     padding: 8px;
     border-radius: 4px;
     transition: background-color 0.2s ease;
+    text-align: left;
+    font-size: 14px;
+    font-family: inherit;
 }
 
-.examples li:hover {
+.example-btn:hover {
     background-color: #e9ecef;
+    color: #333;
+}
+
+.example-btn:focus {
+    outline: 2px solid #007bff;
+    outline-offset: 2px;
 }

--- a/public/css/prefecture.css
+++ b/public/css/prefecture.css
@@ -1,0 +1,147 @@
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background-color: #f5f5f5;
+    padding: 20px;
+}
+
+.container {
+    max-width: 800px;
+    margin: 0 auto;
+    background: white;
+    border-radius: 8px;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+    padding: 40px;
+}
+
+h1 {
+    text-align: center;
+    color: #333;
+    margin-bottom: 30px;
+    font-size: 28px;
+}
+
+.form-group {
+    margin-bottom: 20px;
+}
+
+label {
+    display: block;
+    margin-bottom: 8px;
+    font-weight: 600;
+    color: #555;
+    font-size: 16px;
+}
+
+input[type="text"] {
+    width: 100%;
+    padding: 12px 16px;
+    border: 2px solid #ddd;
+    border-radius: 6px;
+    font-size: 16px;
+    transition: border-color 0.3s ease;
+}
+
+input[type="text"]:focus {
+    outline: none;
+    border-color: #007bff;
+    box-shadow: 0 0 0 3px rgba(0, 123, 255, 0.25);
+}
+
+button {
+    width: 100%;
+    background-color: #007bff;
+    color: white;
+    padding: 12px 24px;
+    border: none;
+    border-radius: 6px;
+    font-size: 16px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background-color 0.3s ease;
+}
+
+button:hover {
+    background-color: #0056b3;
+}
+
+button:disabled {
+    background-color: #6c757d;
+    cursor: not-allowed;
+}
+
+#result {
+    margin-top: 30px;
+    padding: 20px;
+    border-radius: 6px;
+    display: none;
+}
+
+#result.success {
+    background-color: #d4edda;
+    border: 1px solid #c3e6cb;
+    color: #155724;
+}
+
+#result.error {
+    background-color: #f8d7da;
+    border: 1px solid #f5c6cb;
+    color: #721c24;
+}
+
+.result-title {
+    font-weight: 600;
+    margin-bottom: 10px;
+    font-size: 18px;
+}
+
+.loading {
+    display: inline-block;
+    width: 20px;
+    height: 20px;
+    border: 3px solid #f3f3f3;
+    border-top: 3px solid #007bff;
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+    margin-right: 8px;
+}
+
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}
+
+.examples {
+    margin-top: 20px;
+    padding: 20px;
+    background-color: #f8f9fa;
+    border-radius: 6px;
+}
+
+.examples h3 {
+    color: #333;
+    margin-bottom: 15px;
+    font-size: 18px;
+}
+
+.examples ul {
+    list-style: none;
+}
+
+.examples li {
+    margin-bottom: 8px;
+    color: #666;
+    cursor: pointer;
+    padding: 8px;
+    border-radius: 4px;
+    transition: background-color 0.2s ease;
+}
+
+.examples li:hover {
+    background-color: #e9ecef;
+}

--- a/public/js/prefecture.js
+++ b/public/js/prefecture.js
@@ -1,0 +1,133 @@
+document.addEventListener('DOMContentLoaded', function() {
+    const form = document.getElementById('prefecture-form');
+    const addressInput = document.getElementById('address');
+    const resultDiv = document.getElementById('result');
+    const submitButton = form.querySelector('button[type="submit"]');
+
+    // API endpoint from config
+    const API_ENDPOINT = '/api/extract-prefecture';
+
+    function fillAddress(address) {
+        addressInput.value = address;
+        addressInput.focus();
+    }
+
+    function showResult(message, isSuccess) {
+        resultDiv.style.display = 'block';
+        resultDiv.className = isSuccess ? 'success' : 'error';
+
+        // Clear previous content
+        resultDiv.innerHTML = '';
+
+        // Create title element
+        const titleDiv = document.createElement('div');
+        titleDiv.className = 'result-title';
+        titleDiv.textContent = isSuccess ? '抽出結果' : 'エラー';
+        resultDiv.appendChild(titleDiv);
+
+        // Create message element - safely handle HTML content
+        const messageDiv = document.createElement('div');
+        if (isSuccess && typeof message === 'string' && message.includes('抽出された都道府県:')) {
+            const parts = message.split(': ');
+            if (parts.length === 2) {
+                const labelSpan = document.createElement('span');
+                labelSpan.textContent = parts[0] + ': ';
+                const prefectureSpan = document.createElement('strong');
+                prefectureSpan.textContent = parts[1].replace(/<\/?strong>/g, '');
+                messageDiv.appendChild(labelSpan);
+                messageDiv.appendChild(prefectureSpan);
+            } else {
+                messageDiv.textContent = message.replace(/<\/?strong>/g, '');
+            }
+        } else {
+            messageDiv.textContent = message;
+        }
+        resultDiv.appendChild(messageDiv);
+    }
+
+    function showLoading() {
+        submitButton.disabled = true;
+        submitButton.innerHTML = '<span class="loading"></span>処理中...';
+    }
+
+    function hideLoading() {
+        submitButton.disabled = false;
+        submitButton.innerHTML = '都道府県を抽出';
+    }
+
+    function validateAddress(address) {
+        if (!address || address.trim().length === 0) {
+            return '住所を入力してください。';
+        }
+        if (address.length > 200) {
+            return '住所は200文字以内で入力してください。';
+        }
+        return null;
+    }
+
+    // Handle form submission
+    form.addEventListener('submit', async function(e) {
+        e.preventDefault();
+
+        const address = addressInput.value.trim();
+        const validationError = validateAddress(address);
+
+        if (validationError) {
+            showResult(validationError, false);
+            return;
+        }
+
+        showLoading();
+        resultDiv.style.display = 'none';
+
+        try {
+            const csrfToken = document.querySelector('meta[name="csrf-token"]');
+            if (!csrfToken) {
+                throw new Error('CSRFトークンが見つかりません。');
+            }
+
+            const response = await fetch(API_ENDPOINT, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRF-TOKEN': csrfToken.getAttribute('content')
+                },
+                body: JSON.stringify({ address: address })
+            });
+
+            if (!response.ok) {
+                throw new Error(`HTTP error! status: ${response.status}`);
+            }
+
+            const data = await response.json();
+
+            if (data.prefecture) {
+                showResult(`抽出された都道府県: ${data.prefecture}`, true);
+            } else {
+                showResult(data.message || 'データの形式が正しくありません。', false);
+            }
+        } catch (error) {
+            console.error('Error:', error);
+            if (error.name === 'TypeError' && error.message.includes('fetch')) {
+                showResult('ネットワークエラーが発生しました。インターネット接続を確認してください。', false);
+            } else if (error.name === 'SyntaxError') {
+                showResult('サーバーからの応答が正しくありません。', false);
+            } else {
+                showResult('通信エラーが発生しました。しばらくしてからもう一度お試しください。', false);
+            }
+        } finally {
+            hideLoading();
+        }
+    });
+
+    // Handle example button clicks
+    document.querySelectorAll('.example-btn').forEach(button => {
+        button.addEventListener('click', function() {
+            const address = this.dataset.address;
+            fillAddress(address);
+        });
+    });
+
+    // Make fillAddress function globally accessible for backwards compatibility
+    window.fillAddress = fillAddress;
+});

--- a/resources/views/prefecture/index.blade.php
+++ b/resources/views/prefecture/index.blade.php
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>都道府県抽出API</title>
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+    <link rel="stylesheet" href="{{ asset('css/prefecture.css') }}">
+</head>
+<body>
+    <div class="container">
+        <h1>都道府県抽出API</h1>
+
+        <form id="prefecture-form">
+            <div class="form-group">
+                <label for="address">住所を入力してください</label>
+                <input type="text" id="address" name="address" maxlength="200" required
+                       placeholder="例: 〒314-0007 茨城県鹿嶋市神向寺後山２６−２">
+            </div>
+            <button type="submit">都道府県を抽出</button>
+        </form>
+
+        <div id="result"></div>
+
+        <div class="examples">
+            <h3>入力例</h3>
+            <ul>
+                <li onclick="fillAddress('〒314-0007 茨城県鹿嶋市神向寺後山２６−２')">〒314-0007 茨城県鹿嶋市神向寺後山２６−２</li>
+                <li onclick="fillAddress('茨城県鹿嶋市神向寺後山２６−２')">茨城県鹿嶋市神向寺後山２６−２</li>
+                <li onclick="fillAddress('鹿嶋市神向寺後山２６−２')">鹿嶋市神向寺後山２６−２</li>
+                <li onclick="fillAddress('京都市中京区烏丸通二条下ル二条殿町538')">京都市中京区烏丸通二条下ル二条殿町538</li>
+                <li onclick="fillAddress('東京都新宿区歌舞伎町1-1-1')">東京都新宿区歌舞伎町1-1-1</li>
+            </ul>
+        </div>
+    </div>
+
+    <script>
+        const form = document.getElementById('prefecture-form');
+        const addressInput = document.getElementById('address');
+        const resultDiv = document.getElementById('result');
+        const submitButton = form.querySelector('button[type="submit"]');
+
+        function fillAddress(address) {
+            addressInput.value = address;
+        }
+
+        function showResult(message, isSuccess) {
+            resultDiv.style.display = 'block';
+            resultDiv.className = isSuccess ? 'success' : 'error';
+            resultDiv.innerHTML = `<div class="result-title">${isSuccess ? '抽出結果' : 'エラー'}</div>${message}`;
+        }
+
+        function showLoading() {
+            submitButton.disabled = true;
+            submitButton.innerHTML = '<span class="loading"></span>処理中...';
+        }
+
+        function hideLoading() {
+            submitButton.disabled = false;
+            submitButton.innerHTML = '都道府県を抽出';
+        }
+
+        form.addEventListener('submit', async function(e) {
+            e.preventDefault();
+
+            const address = addressInput.value.trim();
+            if (!address) {
+                showResult('住所を入力してください。', false);
+                return;
+            }
+
+            showLoading();
+            resultDiv.style.display = 'none';
+
+            try {
+                const response = await fetch('/api/extract-prefecture', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').getAttribute('content')
+                    },
+                    body: JSON.stringify({ address: address })
+                });
+
+                const data = await response.json();
+
+                if (response.ok) {
+                    showResult(`抽出された都道府県: <strong>${data.prefecture}</strong>`, true);
+                } else {
+                    showResult(data.message || 'エラーが発生しました。', false);
+                }
+            } catch (error) {
+                console.error('Error:', error);
+                showResult('通信エラーが発生しました。しばらくしてからもう一度お試しください。', false);
+            } finally {
+                hideLoading();
+            }
+        });
+    </script>
+</body>
+</html>

--- a/resources/views/prefecture/index.blade.php
+++ b/resources/views/prefecture/index.blade.php
@@ -47,7 +47,10 @@
         function showResult(message, isSuccess) {
             resultDiv.style.display = 'block';
             resultDiv.className = isSuccess ? 'success' : 'error';
-            resultDiv.innerHTML = `<div class="result-title">${isSuccess ? '抽出結果' : 'エラー'}</div>${message}`;
+            resultDiv.innerHTML = `<div class="result-title">${isSuccess ? '抽出結果' : 'エラー'}</div>`;
+            const messageDiv = document.createElement('div');
+            messageDiv.textContent = message;
+            resultDiv.appendChild(messageDiv);
         }
 
         function showLoading() {

--- a/resources/views/prefecture/index.blade.php
+++ b/resources/views/prefecture/index.blade.php
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>都道府県抽出API</title>
     <meta name="csrf-token" content="{{ csrf_token() }}">
-    <link rel="stylesheet" href="{{ asset('css/prefecture.css') }}">
+    <link rel="stylesheet" href="{{ asset('css/prefecture.css') }}?v={{ config('app.version', '1.0') }}">
 </head>
 <body>
     <div class="container">
@@ -25,80 +25,15 @@
         <div class="examples">
             <h3>入力例</h3>
             <ul>
-                <li><button type="button" onclick="fillAddress('〒314-0007 茨城県鹿嶋市神向寺後山２６−２')">〒314-0007 茨城県鹿嶋市神向寺後山２６−２</button></li>
-                <li><button type="button" onclick="fillAddress('茨城県鹿嶋市神向寺後山２６−２')">茨城県鹿嶋市神向寺後山２６−２</button></li>
-                <li><button type="button" onclick="fillAddress('鹿嶋市神向寺後山２６−２')">鹿嶋市神向寺後山２６−２</button></li>
-                <li><button type="button" onclick="fillAddress('京都市中京区烏丸通二条下ル二条殿町538')">京都市中京区烏丸通二条下ル二条殿町538</button></li>
-                <li><button type="button" onclick="fillAddress('東京都新宿区歌舞伎町1-1-1')">東京都新宿区歌舞伎町1-1-1</button></li>
+                <li><button type="button" class="example-btn" data-address="〒314-0007 茨城県鹿嶋市神向寺後山２６−２">〒314-0007 茨城県鹿嶋市神向寺後山２６−２</button></li>
+                <li><button type="button" class="example-btn" data-address="茨城県鹿嶋市神向寺後山２６−２">茨城県鹿嶋市神向寺後山２６−２</button></li>
+                <li><button type="button" class="example-btn" data-address="鹿嶋市神向寺後山２６−２">鹿嶋市神向寺後山２６−２</button></li>
+                <li><button type="button" class="example-btn" data-address="京都市中京区烏丸通二条下ル二条殿町538">京都市中京区烏丸通二条下ル二条殿町538</button></li>
+                <li><button type="button" class="example-btn" data-address="東京都新宿区歌舞伎町1-1-1">東京都新宿区歌舞伎町1-1-1</button></li>
             </ul>
         </div>
     </div>
 
-    <script>
-        const form = document.getElementById('prefecture-form');
-        const addressInput = document.getElementById('address');
-        const resultDiv = document.getElementById('result');
-        const submitButton = form.querySelector('button[type="submit"]');
-
-        function fillAddress(address) {
-            addressInput.value = address;
-        }
-
-        function showResult(message, isSuccess) {
-            resultDiv.style.display = 'block';
-            resultDiv.className = isSuccess ? 'success' : 'error';
-            resultDiv.innerHTML = `<div class="result-title">${isSuccess ? '抽出結果' : 'エラー'}</div>`;
-            const messageDiv = document.createElement('div');
-            messageDiv.textContent = message;
-            resultDiv.appendChild(messageDiv);
-        }
-
-        function showLoading() {
-            submitButton.disabled = true;
-            submitButton.innerHTML = '<span class="loading"></span>処理中...';
-        }
-
-        function hideLoading() {
-            submitButton.disabled = false;
-            submitButton.innerHTML = '都道府県を抽出';
-        }
-
-        form.addEventListener('submit', async function(e) {
-            e.preventDefault();
-
-            const address = addressInput.value.trim();
-            if (!address) {
-                showResult('住所を入力してください。', false);
-                return;
-            }
-
-            showLoading();
-            resultDiv.style.display = 'none';
-
-            try {
-                const response = await fetch('/api/extract-prefecture', {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
-                        'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').getAttribute('content')
-                    },
-                    body: JSON.stringify({ address: address })
-                });
-
-                const data = await response.json();
-
-                if (response.ok) {
-                    showResult(`抽出された都道府県: <strong>${data.prefecture}</strong>`, true);
-                } else {
-                    showResult(data.message || 'エラーが発生しました。', false);
-                }
-            } catch (error) {
-                console.error('Error:', error);
-                showResult('通信エラーが発生しました。しばらくしてからもう一度お試しください。', false);
-            } finally {
-                hideLoading();
-            }
-        });
-    </script>
+    <script src="{{ asset('js/prefecture.js') }}?v={{ config('app.version', '1.0') }}"></script>
 </body>
 </html>

--- a/resources/views/prefecture/index.blade.php
+++ b/resources/views/prefecture/index.blade.php
@@ -25,11 +25,11 @@
         <div class="examples">
             <h3>入力例</h3>
             <ul>
-                <li onclick="fillAddress('〒314-0007 茨城県鹿嶋市神向寺後山２６−２')">〒314-0007 茨城県鹿嶋市神向寺後山２６−２</li>
-                <li onclick="fillAddress('茨城県鹿嶋市神向寺後山２６−２')">茨城県鹿嶋市神向寺後山２６−２</li>
-                <li onclick="fillAddress('鹿嶋市神向寺後山２６−２')">鹿嶋市神向寺後山２６−２</li>
-                <li onclick="fillAddress('京都市中京区烏丸通二条下ル二条殿町538')">京都市中京区烏丸通二条下ル二条殿町538</li>
-                <li onclick="fillAddress('東京都新宿区歌舞伎町1-1-1')">東京都新宿区歌舞伎町1-1-1</li>
+                <li><button type="button" onclick="fillAddress('〒314-0007 茨城県鹿嶋市神向寺後山２６−２')">〒314-0007 茨城県鹿嶋市神向寺後山２６−２</button></li>
+                <li><button type="button" onclick="fillAddress('茨城県鹿嶋市神向寺後山２６−２')">茨城県鹿嶋市神向寺後山２６−２</button></li>
+                <li><button type="button" onclick="fillAddress('鹿嶋市神向寺後山２６−２')">鹿嶋市神向寺後山２６−２</button></li>
+                <li><button type="button" onclick="fillAddress('京都市中京区烏丸通二条下ル二条殿町538')">京都市中京区烏丸通二条下ル二条殿町538</button></li>
+                <li><button type="button" onclick="fillAddress('東京都新宿区歌舞伎町1-1-1')">東京都新宿区歌舞伎町1-1-1</button></li>
             </ul>
         </div>
     </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,5 +3,9 @@
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
-    return view('welcome');
+    return view('prefecture.index');
+});
+
+Route::get('/prefecture', function () {
+    return view('prefecture.index');
 });


### PR DESCRIPTION
## Summary
- 都道府県抽出API用のフロントエンド画面を実装
- 住所入力フォームと結果表示機能を追加
- CSSを外部ファイルに分離し、可読性を向上

## Test plan
- [x] ブラウザで`/`または`/prefecture`にアクセスして画面が表示されることを確認
- [x] 住所入力フォームが正しく表示されることを確認
- [x] 入力例をクリックして住所フィールドに値が設定されることを確認
- [x] CSSスタイルが正しく適用されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)